### PR TITLE
店舗の外観画像をPlaces APIを用いて取得するよう実装した

### DIFF
--- a/app/decorators/shop_decorator.rb
+++ b/app/decorators/shop_decorator.rb
@@ -108,7 +108,7 @@ module ShopDecorator
     if photo_url_update_at.nil? || Time.zone.now >= photo_url_update_at
       url = "https://maps.googleapis.com/maps/api/place/photo?maxwidth=1000&photoreference=#{photo_reference}&key=#{ENV['PLACES_API_KEY']}"
       redirect_url = Net::HTTP.get_response(URI.parse(url))['location']
-      Shop.find(id).update(photo_url: redirect_url, photo_url_update_at: Time.zone.now + 1.day)
+      Shop.find(id).update(photo_url: redirect_url, photo_url_update_at: Time.zone.now + 1.day) if redirect_url.present?
     end
     self.reload.photo_url
   end

--- a/app/decorators/shop_decorator.rb
+++ b/app/decorators/shop_decorator.rb
@@ -102,4 +102,14 @@ module ShopDecorator
     end
     time_ranges
   end
+
+  def get_photo_url
+    return asset_pack_path 'media/images/appearance_img.png' if photo_reference.nil? || games.size <= 2
+    if photo_url_update_at.nil? || Time.zone.now >= photo_url_update_at
+      url = "https://maps.googleapis.com/maps/api/place/photo?maxwidth=1000&photoreference=#{photo_reference}&key=#{ENV['PLACES_API_KEY']}"
+      redirect_url = Net::HTTP.get_response(URI.parse(url))['location']
+      Shop.find(id).update(photo_url: redirect_url, photo_url_update_at: Time.zone.now + 1.day)
+    end
+    self.reload.photo_url
+  end
 end

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -285,12 +285,20 @@ header {
   .shop-head {
     margin-bottom: 10px;
   }
-  .appearance_img {
-    max-width: 160px;
-    max-height: 120px;
+  .shop-img-container {
+    min-width: 160px;
+    min-height: 120px;
+    width: 160px;
+    height: 120px;
     border-radius: 10px;
     box-shadow: 0 0 6px 0 rgba(white, 0.7);
     margin-right: 20px;
+    .appearance_img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      border-radius: 10px;
+    }
   }
   .ordered-list {
     width: 35px;
@@ -638,7 +646,7 @@ footer {
     .adjust-position {
       top: -70px;
     }
-    .appearance_img {
+    .appearance_img, .shop-img-container {
       display: none;
     }
     .ordered-list {

--- a/app/javascript/stylesheets/shop-detail.scss
+++ b/app/javascript/stylesheets/shop-detail.scss
@@ -1,7 +1,7 @@
 .shop-appearance-img-container {
   position: relative;
   border-radius: 20px 20px 0 0;
-  height: 200px;
+  height: 400px;
   padding: 0;
   background: rgba(white, 0.3);
   border: 1 solid rgba(white, 0.3);
@@ -166,8 +166,9 @@
 @include media-breakpoint-down(sm) {
   .shop-appearance-img-container {
     border-radius: 10px 10px 0 0;
+    height: 200px;
     .img-cover {
-      background: linear-gradient(rgba(black, 0), rgba(black, 0) 70%,  rgba(black, 0.3) 90%, rgba(black, 0.4));
+      background: linear-gradient(rgba(black, 0), rgba(black, 0) 60%,  rgba(black, 0.8) 90%, rgba(black, 0.9));
       p {
         font-size: 1rem;
         margin: 0 10px 3px 0;

--- a/app/views/shops/_description.html.slim
+++ b/app/views/shops/_description.html.slim
@@ -2,7 +2,7 @@ input.d-none#table-check type="checkbox"
 .col-12.shop-appearance-img-container.d-flex.align-content-start
   .img-cover.d-flex.justify-content-end.align-items-end
     p = shop.name
-  = image_pack_tag 'appearance_img.png'
+  img src="#{shop.get_photo_url}"
 .col-12.glass.shop-description-container
   .game-machines
     label.shop-label.rounded-pill = GameMachine.model_name.human

--- a/app/views/shops/_shop.html.slim
+++ b/app/views/shops/_shop.html.slim
@@ -1,7 +1,8 @@
 = link_to shop_path(shop.id) do
   .col-12.glass.shop-card.d-flex.align-content-start
     .adjust-position id="shop-#{shop.id}"
-    = image_pack_tag 'appearance_img.png', class: 'appearance_img'
+    .shop-img-container
+      img.appearance_img src="#{shop.get_photo_url}"
     .shop-description.d-flex.flex-column.justify-content-start
       .shop-head.d-flex.align-items-start
         .ordered-list.rounded-circle.d-flex.align-items-center.justify-content-center

--- a/db/migrate/20210715033158_add_photo_url_to_shops.rb
+++ b/db/migrate/20210715033158_add_photo_url_to_shops.rb
@@ -1,0 +1,6 @@
+class AddPhotoUrlToShops < ActiveRecord::Migration[6.0]
+  def change
+    add_column :shops, :photo_url, :string
+    add_column :shops, :photo_url_update_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_11_132120) do
+ActiveRecord::Schema.define(version: 2021_07_15_033158) do
 
   create_table "about_games", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.bigint "user_review_id", null: false
@@ -80,6 +80,8 @@ ActiveRecord::Schema.define(version: 2021_07_11_132120) do
     t.string "place_id"
     t.decimal "lat", precision: 10, scale: 7
     t.decimal "lng", precision: 10, scale: 7
+    t.string "photo_url"
+    t.datetime "photo_url_update_at"
     t.index ["city_id"], name: "index_shops_on_city_id"
     t.index ["name"], name: "index_shops_on_name", unique: true
     t.index ["prefecture_id"], name: "index_shops_on_prefecture_id"


### PR DESCRIPTION
## 概要

- Google Places APIを用いて店舗外観画像を取得するよう実装した.
- 今後ユーザモデルの実装を行った後店舗外観画像を投稿出来るよう実装する予定.
- その際は ユーザ投稿店舗外観画像 > ユーザ投稿筐体画像 > Places API画像の優先度順で店舗外観画像に表示する.
