### PR TITLE
マップに周辺店舗検索機能を追加した

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # OTOMAP | みんなで作る音ゲーマップ
 
-![site image](app/assets/images/site_image.png)
+![site image](app/javascript/images/site_image.png)
 
 ## サービス概要
 ゲームセンターを探している音ゲーマーが求めている音楽ゲーム筐体の設置店舗をマップ検索出来るサービスです。
 
-## 登場人物
-- エンドユーザー
-  - ゲームセンターで音楽ゲームをプレイする人
+## エンドユーザー
+- ゲームセンターで音楽ゲームをプレイする人
 
 ## ユーザが抱える課題
 1. 各音楽ゲーム公式サイトの設置店舗検索機能は検索結果がリスト表示でマップ一覧表示が出来ません。  
@@ -40,4 +39,4 @@ jubeatやREFLEC BEATでは筐体にイヤホンジャックが無いため、筐
 https://xd.adobe.com/view/4befa147-7997-4f29-8056-00eb881f1444-1ebc/grid
 
 ## ER図
-https://drive.google.com/file/d/1PYmvrzjo2Ce26POjbrVXHhdxw8cN7hnp/view
+https://drive.google.com/file/d/1P_FSH4hBaQocHciW_F3kSfudXvsTiQ_M/view

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :set_search
-  before_action :local_set
+  before_action :set_variable_to_javascript
 
   private
 
@@ -13,8 +13,10 @@ class ApplicationController < ActionController::Base
     @shops = Shop.ransack(search_hash).result
   end
 
-  def local_set
-    @prefectures = Prefecture.all
-    @cities = Prefecture.find(session[:prefecture_id]).cities if session[:prefecture_id]
+  def set_variable_to_javascript
+    gon.selectedPref = session[:prefecture_id]
+    gon.selectedCity = session[:city_id]
+    gon.prefectures = Prefecture.all.to_json only: %i[id name]
+    gon.cities = Prefecture.find(gon.selectedPref).cities.to_json(only: %i[id name]) if gon.selectedPref
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,8 @@ class ApplicationController < ActionController::Base
   def set_variable_to_javascript
     gon.selectedPref = session[:prefecture_id]
     gon.selectedCity = session[:city_id]
+    gon.location = session[:location] if session[:location]
+    gon.selectedCity = session[:city_id]
     gon.prefectures = Prefecture.all.to_json only: %i[id name]
     gon.cities = Prefecture.find(gon.selectedPref).cities.to_json(only: %i[id name]) if gon.selectedPref
   end

--- a/app/controllers/filters_controller.rb
+++ b/app/controllers/filters_controller.rb
@@ -1,24 +1,38 @@
 class FiltersController < ApplicationController
   def create
+    if params[:prefecture]
+      session.delete :lat
+      session.delete :lng
+    end
     session[:prefecture_id] = params[:prefecture]
     session[:city_id] = params[:city]
     session[:games] = params[:games]
-    session[:lat] = params[:lat]
-    session[:lng] = params[:lng]
-    redirect_back(fallback_location: root_path)
+    redirect_to root_path
   end
 
   def destroy
     session.delete :prefecture_id
     session.delete :city_id
     session.delete :games
+    redirect_to root_path
+  end
+
+  def clear_location
     session.delete :lat
     session.delete :lng
-    redirect_back(fallback_location: root_path)
+    redirect_to root_path, notice: '周辺検索設定をクリアしました'
   end
 
   def cities_select
     cities = Prefecture.find_by(id: params[:id]).cities
     render json: cities.all.to_json(only: %i[id name])
+  end
+
+  def set_location
+    session[:lat] = params[:lat]
+    session[:lng] = params[:lng]
+    session.delete :prefecture_id
+    session.delete :city_id
+    redirect_to root_path
   end
 end

--- a/app/controllers/filters_controller.rb
+++ b/app/controllers/filters_controller.rb
@@ -17,10 +17,10 @@ class FiltersController < ApplicationController
     redirect_to root_path
   end
 
-  def clear_location
+  def clear_near_shops_search
     session.delete :lat
     session.delete :lng
-    redirect_to root_path, notice: '周辺検索設定をクリアしました'
+    redirect_to root_path, notice: t('defaults.map_flash_message.clear_near_shops_search')
   end
 
   def cities_select
@@ -28,11 +28,15 @@ class FiltersController < ApplicationController
     render json: cities.all.to_json(only: %i[id name])
   end
 
-  def set_location
+  def near_shops_search
     session[:lat] = params[:lat]
     session[:lng] = params[:lng]
     session.delete :prefecture_id
     session.delete :city_id
-    redirect_to root_path
+    redirect_to root_path, notice: t('defaults.map_flash_message.near_shops_search')
+  end
+
+  def set_location
+    session[:location] = [params[:lat], params[:lng]]
   end
 end

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -28,6 +28,6 @@ class ShopsController < ApplicationController
   end
 
   def set_shops_lat_and_lng
-    @shops_lat_and_lng = @shops_filter.includes(:games).page(params[:page])
+    gon.shops_lat_and_lng = @shops_filter.includes(:games).page(params[:page]).to_json only: %i[id lat lng]
   end
 end

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -16,7 +16,6 @@ class ShopsController < ApplicationController
     @shops_filter = @shops
     @shops_filter = @shops_filter.in_prefecture(session[:prefecture_id]) if session[:prefecture_id]
     @shops_filter = @shops_filter.in_city(session[:city_id]) if session[:city_id]
-    @shops_filter = @shops_filter.within(2, origin: [session[:lat], session[:lng]]) if session[:lat]
     session[:games]&.each do |g|
       # g.first: Game.id
       # g.last: 0 => フィルターなし, 1 => フィルターあり
@@ -25,6 +24,7 @@ class ShopsController < ApplicationController
         @shops_filter = Shop.where(id: @shops_filter.includes(:games).map { |s| s.id if s.games.include?(game) }.compact)
       end
     end
+    @shops_filter = @shops_filter.by_distance(origin: [session[:lat], session[:lng]]).limit(20) if session[:lat]
   end
 
   def set_shops_lat_and_lng

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,7 +5,7 @@ module ApplicationHelper
   end
 
   def filtered?
-    session[:prefecture_id] || games_filtered? || session[:lat]
+    session[:prefecture_id] || games_filtered?
   end
 
   def games_filtered?

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -27,11 +27,11 @@ axios.defaults.headers.common = {
 export default {
   data: function () {
     return {
-      selectedPref: filterHash.prefecture_id,
-      selectedCity: filterHash.city_id,
-      prefectures: prefHash,
-      cities: cityHash,
-      geoMessage: ''
+      selectedPref: gon.selectedPref,
+      selectedCity: gon.selectedCity,
+      prefectures: JSON.parse(gon.prefectures),
+      cities: gon.cities != null ? JSON.parse(gon.cities) : [],
+      geoMessage: '',
     }
   },
   methods: {

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -1,23 +1,16 @@
 <template>
   <div id="form-vue">
     <div class="d-flex align-items-center">
-      <div class="select-container" :class="{ disabled: isGeoChecked }">
-        <select class="filter-select" name="prefecture" id="prefecture" v-model="selectedPref" @change="getCities(selectedPref)" :disabled="isGeoChecked">
+      <div class="select-container">
+        <select class="filter-select" name="prefecture" id="prefecture" v-model="selectedPref" @change="getCities(selectedPref)">
           <option v-for="prefecture in prefectures" :key="prefecture.name" :value="prefecture.id">{{prefecture.name}}</option>
         </select>
       </div>
-      <div class="select-container" :class="{ disabled: isGeoChecked }">
-        <select class="filter-select" name="city" id="city" v-model="selectedCity" :disabled="isGeoChecked">
+      <div class="select-container">
+        <select class="filter-select" name="city" id="city" v-model="selectedCity">
           <option v-for="city in cities" :key="city.name" :value="city.id">{{city.name}}</option>
         </select>
       </div>
-    </div>
-    <div class="geo-checkbox">
-      <input type="checkbox" name="geo-check" id="geo-check" v-model="isGeoChecked" v-on:change="getGeolocation(isGeoChecked)">
-      <label for="geo-check">現在位置周辺を検索する</label>
-      <span class="geo-message" :hidden="!isGeoChecked">{{geoMessage}}</span>
-      <input type="hidden" name="lat" id="lat" :value="latitude" :disabled="!isGeoChecked">
-      <input type="hidden" name="lng" id="lng" :value="longitude" :disabled="!isGeoChecked">
     </div>
   </div>
 </template>
@@ -38,9 +31,6 @@ export default {
       selectedCity: filterHash.city_id,
       prefectures: prefHash,
       cities: cityHash,
-      latitude: filterHash.lat,
-      longitude: filterHash.lng,
-      isGeoChecked: filterHash.lat == null ? false : true,
       geoMessage: ''
     }
   },
@@ -53,46 +43,6 @@ export default {
         .then((response) => {
           this.cities = response.data
         })
-    },
-    getGeolocation: function(isGeoChecked) {
-      if(isGeoChecked) {
-        if (!navigator.geolocation) {
-          this.setMessage('現在位置が取得できませんでした')
-          return
-        }
-        const options = {
-          enableHighAccuracy: false,
-          timeout: 5000,
-          maximumAge: 0
-        }
-        navigator.geolocation.getCurrentPosition(this.success, this.error, options)
-        this.geoMessage = '現在位置を取得中です...'
-      }
-    },
-    success: function(position) {
-      this.latitude = position.coords.latitude
-      this.longitude = position.coords.longitude
-      this.setMessage('現在位置を取得中しました')
-    },
-    error: function(error) {
-      switch (error.code) {
-        case 1: // PERMISSION_DENIED
-          this.setMessage('位置情報の利用が許可されていません')
-          break
-        case 2: // POSITION_UNAVAILABLE
-          this.setMessage('現在位置が取得できませんでした')
-          break
-        case 3: // TIMEOUT
-          this.setMessage('タイムアウトになりました')
-          break
-        default:
-          this.setMessage('現在位置が取得できませんでした')
-          break
-      }
-    },
-    setMessage: function(message) {
-      this.geoMessage = message
-      setTimeout( () => { this.geoMessage = '' }, 3000 )
     }
   }
 }

--- a/app/javascript/geolocation_button.vue
+++ b/app/javascript/geolocation_button.vue
@@ -1,0 +1,71 @@
+<template>
+  <div id="geolocationButton">
+    <input class="d-none" type="checkbox" id="dialog-check" v-model="isDialogChecked">
+    <div class="map-message-dialog blur">
+      <p>{{geoMessage}}</p>
+    </div>
+    <button class="update-geo-button" @click="getGeolocation()">
+      <div class="icon-container" :class="{ 'icon-blue': isGeoChecked }">
+        <i class="fas fa-crosshairs"></i>
+      </div>
+    </button>
+  </div>
+</template>
+
+<script>
+export default {
+  data: function () {
+    return {
+      isGeoChecked: false,
+      isDialogChecked: false,
+      geoMessage: ''
+    }
+  },
+  methods: {
+    getGeolocation: function() {
+      if (!navigator.geolocation) {
+        this.setGeoMessage('現在位置が取得できませんでした')
+        return
+      }
+      const options = {
+        enableHighAccuracy: true,
+        timeout: 5000,
+        maximumAge: 0
+      }
+      this.setGeoMessage('現在位置情報を取得しています...')
+      navigator.geolocation.getCurrentPosition(this.success, this.error, options)
+    },
+    success: function(position) {
+      this.latitude = position.coords.latitude
+      this.longitude = position.coords.longitude
+      this.isGeoChecked = true;
+      window.globalFunction.addGeoLocationMarker([this.latitude, this.longitude]);
+      this.setGeoMessage('現在位置を取得しました')
+    },
+    error: function(error) {
+      switch (error.code) {
+        case 1: // PERMISSION_DENIED
+          this.setGeoMessage('位置情報の利用が許可されていません')
+          break
+        case 2: // POSITION_UNAVAILABLE
+          this.setGeoMessage('現在位置が取得できませんでした')
+          break
+        case 3: // TIMEOUT
+          this.setGeoMessage('タイムアウトになりました')
+          break
+        default:
+          this.setGeoMessage('現在位置が取得できませんでした')
+          break
+      }
+    },
+    setGeoMessage: function(message) {
+      this.geoMessage = message;
+      this.isDialogChecked = true;
+      setTimeout( () => { this.isDialogChecked = false }, 3000 )
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/app/javascript/geolocation_button.vue
+++ b/app/javascript/geolocation_button.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="geolocationButton">
-    <button class="update-geo-button" @click="getGeolocation()">
+    <button class="update-geo-button" id="update-geo-button" @click="getGeolocation()">
       <div class="icon-container" :class="{ 'icon-blue': isGeoChecked }">
         <i class="fas fa-crosshairs"></i>
       </div>

--- a/app/javascript/packs/geolocation.js
+++ b/app/javascript/packs/geolocation.js
@@ -1,0 +1,11 @@
+import Vue from 'vue'
+import App from '../geolocation_button.vue'
+
+Vue.config.productionTip = false
+
+document.addEventListener('DOMContentLoaded', () => {
+  const app = new Vue({
+    el: '#geolocation_button',
+    render: h => h(App)
+  })
+})

--- a/app/javascript/packs/map.js
+++ b/app/javascript/packs/map.js
@@ -58,7 +58,7 @@ let addGeoLocationMarker = (location) => {
     map.removeLayer(own);
   };
   // マーカーを生成
-  own = L.marker(location).addTo(map);
+  createOwnMaker(gon.location);
   // ビューを変更する
   let latAryLocal = latAry;
   let lngAryLocal = lngAry;
@@ -68,6 +68,17 @@ let addGeoLocationMarker = (location) => {
   let lngCenter = calculateCenter(lngAryLocal);
   let zoomLevel = calculateZoomLevel(latAryLocal, lngAryLocal);
   map.setView([latCenter, lngCenter], zoomLevel);
+};
+
+function createOwnMaker(location) {
+  // マーカーを生成
+  let mapIcon = L.divIcon({
+    className: 'own-icon',
+    iconSize: [30, 30],
+    iconAnchor: [15, 15],
+    popupAnchor: [0, -15],
+  });
+  own = L.marker(location,{ icon: mapIcon }).addTo(map);
 };
 
 let getMapCenter = () => {
@@ -116,7 +127,7 @@ function calculateZoomLevel(latAry, lngAry) {
 // window.onloadが何故か動かないため直書きしてます
 // 現在位置が取得されていたら現在地マーカーを表示する
 if(gon.location != null) {
-  own = L.marker(gon.location).addTo(map);
+  createOwnMaker(gon.location)
 }
 // 中心位置初期設定
 inputCenterPos();

--- a/app/javascript/packs/map.js
+++ b/app/javascript/packs/map.js
@@ -1,14 +1,13 @@
 import MapIconImage from '../images/map_icon.png'
 
-let shopsLatAndLon = document.getElementById('shops-lat-and-lng');
-let shopsLatAndLonObject = JSON.parse(shopsLatAndLon.getAttribute('data-shops-lat-and-lng'));
+let shopsLatAndLng = JSON.parse(gon.shops_lat_and_lng);
 
 // オブジェクトから緯度経度の配列を作成
 let latAry = [];
 let lngAry = [];
-Object.keys(shopsLatAndLonObject).forEach(function (key) {
-  latAry.push(parseFloat(shopsLatAndLonObject[key].lat));
-  lngAry.push(parseFloat(shopsLatAndLonObject[key].lng));
+Object.keys(shopsLatAndLng).forEach(function (key) {
+  latAry.push(parseFloat(shopsLatAndLng[key].lat));
+  lngAry.push(parseFloat(shopsLatAndLng[key].lng));
 });
 
 // Mapの中央座標を算出
@@ -28,10 +27,10 @@ let tileLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
   attribution: '© <a href="http://osm.org/copyright">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>',
 });
 tileLayer.addTo(map);
-Object.keys(shopsLatAndLonObject).forEach(function (key) {
+Object.keys(shopsLatAndLng).forEach(function (key) {
   let mapIcon = L.divIcon({
     className: 'map-icon-container',
-    html: '<a href="#shop-' + shopsLatAndLonObject[key].id + '">' +
+    html: '<a href="#shop-' + shopsLatAndLng[key].id + '">' +
           '<img src="' + MapIconImage + '" style="width:50px; height:52.5px;">' +
           '<span class="map-icon-text">' + (Number(key) + 1) + '</span>' +
           '</a>',
@@ -39,7 +38,7 @@ Object.keys(shopsLatAndLonObject).forEach(function (key) {
     iconAnchor: [25, 52.5],
     popupAnchor: [0, -52.5],
   });
-  L.marker([parseFloat(shopsLatAndLonObject[key].lat), parseFloat(shopsLatAndLonObject[key].lng)],{ icon: mapIcon }).addTo(map);
+  L.marker([parseFloat(shopsLatAndLng[key].lat), parseFloat(shopsLatAndLng[key].lng)],{ icon: mapIcon }).addTo(map);
 });
 
 // マップが動いたら中心座標を出力
@@ -121,11 +120,11 @@ function initMap() {
     center: { lat: latCenter, lng: lngCenter },
     zoom: zoomLevel,
   });
-  Object.keys(shopsLatAndLonObject).forEach(function (key) {
+  Object.keys(shopsLatAndLng).forEach(function (key) {
     marker[key] = new google.maps.Marker({
       position: {
-        lat: parseFloat(shopsLatAndLonObject[key].lat),
-        lng: parseFloat(shopsLatAndLonObject[key].lng)
+        lat: parseFloat(shopsLatAndLng[key].lat),
+        lng: parseFloat(shopsLatAndLng[key].lng)
       },
       icon: {
         url: MapIconImage,
@@ -140,7 +139,7 @@ function initMap() {
       },
       map: map
     });
-    let url = '#shop-' + shopsLatAndLonObject[key].id;
+    let url = '#shop-' + shopsLatAndLng[key].id;
     google.maps.event.addListener(marker[key], 'click', (function(url){
       return function(){ location.href = url; };
     })(url));

--- a/app/javascript/packs/map.js
+++ b/app/javascript/packs/map.js
@@ -12,36 +12,24 @@ Object.keys(shopsLatAndLonObject).forEach(function (key) {
 });
 
 // Mapの中央座標を算出
-const aryMax = function (a, b) { return Math.max(a, b); }
-const aryMin = function (a, b) { return Math.min(a, b); }
-let latDelta = latAry.reduce(aryMax) - latAry.reduce(aryMin);
-let lngDelta = lngAry.reduce(aryMax) - lngAry.reduce(aryMin);
-let latCenter = latDelta/2 + latAry.reduce(aryMin);
-let lngCenter = lngDelta/2 + lngAry.reduce(aryMin);
+let latCenter = calculateCenter(latAry);
+let lngCenter = calculateCenter(lngAry);
 
-// Zoomレベルを算出
-// 算出式 (EarthDiameter/2^zoomLevel) = 表示されるサイズ[km]
-// よって zoomLevel = log2(EarthDiameter/表示されるサイズ)
-// 緯度1度 = 111.11km
-let latDeltaKm = latDelta * 111.11;
-let zoomLevel_lat = Math.floor(Math.log(40075/latDeltaKm) / Math.log(2));
-// 経度1度 = 111.11km × cos(35°) = 約 91km
-let lngDeltaKm = lngDelta * 91;
-let zoomLevel_lng = Math.floor(Math.log(40075/lngDeltaKm) / Math.log(2));
-// 緯度と経度のzoomLevelを比較し値が小さい方を採用する
-let zoomLevel = zoomLevel_lat > zoomLevel_lng ? zoomLevel_lng : zoomLevel_lat;
+// ZoomLevelを算出
+let zoomLevel = calculateZoomLevel(latAry, lngAry);
 
-// 以下OpenStreetMap
-var map = L.map('map', {
+// OpenStreetMap生成
+let own = null; // 現在地のピン
+let map = L.map('map', {
   center: [latCenter, lngCenter],
   zoom: zoomLevel,
 });
-var tileLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+let tileLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
   attribution: '© <a href="http://osm.org/copyright">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>',
 });
 tileLayer.addTo(map);
 Object.keys(shopsLatAndLonObject).forEach(function (key) {
-  var sampleIcon = L.divIcon({
+  let mapIcon = L.divIcon({
     className: 'map-icon-container',
     html: '<a href="#shop-' + shopsLatAndLonObject[key].id + '">' +
           '<img src="' + MapIconImage + '" style="width:50px; height:52.5px;">' +
@@ -51,8 +39,77 @@ Object.keys(shopsLatAndLonObject).forEach(function (key) {
     iconAnchor: [25, 52.5],
     popupAnchor: [0, -52.5],
   });
-  var marker = L.marker([parseFloat(shopsLatAndLonObject[key].lat), parseFloat(shopsLatAndLonObject[key].lng)],{ icon: sampleIcon }).addTo(map);
+  L.marker([parseFloat(shopsLatAndLonObject[key].lat), parseFloat(shopsLatAndLonObject[key].lng)],{ icon: mapIcon }).addTo(map);
 });
+
+// マップが動いたら中心座標を出力
+map.on('move', function(e) {
+  inputCenterPos();
+});
+
+function inputCenterPos() {
+  let centerPos = map.getCenter();
+  document.getElementById('map-lat').value = centerPos.lat;
+  document.getElementById('map-lng').value = centerPos.lng;
+};
+
+let addGeoLocationMarker = (location) => {
+  // 古いマーカーを削除
+  if(own != null) {
+    map.removeLayer(own);
+  };
+  // マーカーを生成
+  own = L.marker(location).addTo(map);
+  // ビューを変更する
+  let latAryLocal = latAry;
+  let lngAryLocal = lngAry;
+  latAryLocal.push(location[0]);
+  lngAryLocal.push(location[1]);
+  let latCenter = calculateCenter(latAryLocal);
+  let lngCenter = calculateCenter(lngAryLocal);
+  let zoomLevel = calculateZoomLevel(latAryLocal, lngAryLocal);
+  map.setView([latCenter, lngCenter], zoomLevel);
+};
+let getMapCenter = () => {
+  let centerPosition = map.getCenter();
+  return centerPosition;
+}
+window.globalFunction = {};
+window.getMapCenter = {};
+window.globalFunction.addGeoLocationMarker = addGeoLocationMarker;
+window.globalFunction.getMapCenter = getMapCenter;
+
+function calculateDelta(ary) {
+  const aryMax = function (a, b) { return Math.max(a, b); }
+  const aryMin = function (a, b) { return Math.min(a, b); }
+  let delta = ary.reduce(aryMax) - ary.reduce(aryMin);
+  return delta;
+}
+
+function calculateCenter(ary) {
+  const aryMin = function (a, b) { return Math.min(a, b); }
+  let delta = calculateDelta(ary);
+  let center = delta/2 + ary.reduce(aryMin);
+  return center;
+};
+
+function calculateZoomLevel(latAry, lngAry) {
+  // Zoomレベルを算出
+  // 算出式 (EarthDiameter/2^zoomLevel) = 表示されるサイズ[km]
+  // よって zoomLevel = log2(EarthDiameter/表示されるサイズ)
+  // 緯度1度 = 111.11km
+  let latDelta = calculateDelta(latAry);
+  let latDeltaKm = latDelta * 111.11;
+  let zoomLevel_lat = Math.round(Math.log(40075/latDeltaKm) / Math.log(2));
+  // 経度1度 = 111.11km × cos(35°) = 約 91km
+  let lngDelta = calculateDelta(lngAry);
+  let lngDeltaKm = lngDelta * 91;
+  let zoomLevel_lng = Math.round(Math.log(40075/lngDeltaKm) / Math.log(2));
+  // 緯度と経度のzoomLevelを比較し値が小さい方を採用する
+  let zoomLevel = zoomLevel_lat > zoomLevel_lng ? zoomLevel_lng : zoomLevel_lat;
+  zoomLevel = zoomLevel > 15 ? 15 : zoomLevel;
+  return zoomLevel;
+};
 
 // 以下GoogleMaps
 /*

--- a/app/javascript/packs/map.js
+++ b/app/javascript/packs/map.js
@@ -69,10 +69,12 @@ let addGeoLocationMarker = (location) => {
   let zoomLevel = calculateZoomLevel(latAryLocal, lngAryLocal);
   map.setView([latCenter, lngCenter], zoomLevel);
 };
+
 let getMapCenter = () => {
   let centerPosition = map.getCenter();
   return centerPosition;
 }
+
 window.globalFunction = {};
 window.getMapCenter = {};
 window.globalFunction.addGeoLocationMarker = addGeoLocationMarker;
@@ -110,42 +112,11 @@ function calculateZoomLevel(latAry, lngAry) {
   return zoomLevel;
 };
 
-// 以下GoogleMaps
-/*
-// Map作成
-let map;
-let marker = [];
-function initMap() {
-  map = new google.maps.Map(document.getElementById("map"), {
-    center: { lat: latCenter, lng: lngCenter },
-    zoom: zoomLevel,
-  });
-  Object.keys(shopsLatAndLng).forEach(function (key) {
-    marker[key] = new google.maps.Marker({
-      position: {
-        lat: parseFloat(shopsLatAndLng[key].lat),
-        lng: parseFloat(shopsLatAndLng[key].lng)
-      },
-      icon: {
-        url: MapIconImage,
-        scaledSize: new google.maps.Size(50, 52.5)
-      },
-      label: {
-        text: String(Number(key) + 1),
-        fontSize: '20px',
-        fontWeight: '900',
-        fontFamily: "LEMONMILK-BOLD",
-        color: '#666666'
-      },
-      map: map
-    });
-    let url = '#shop-' + shopsLatAndLng[key].id;
-    google.maps.event.addListener(marker[key], 'click', (function(url){
-      return function(){ location.href = url; };
-    })(url));
-  });
+// 以下初期処理
+// window.onloadが何故か動かないため直書きしてます
+// 現在位置が取得されていたら現在地マーカーを表示する
+if(gon.location != null) {
+  own = L.marker(gon.location).addTo(map);
 }
-window.onload = function () {
-  initMap();
-}
-*/
+// 中心位置初期設定
+inputCenterPos();

--- a/app/javascript/packs/map_flash_message.js
+++ b/app/javascript/packs/map_flash_message.js
@@ -1,0 +1,18 @@
+let flashMessage = document.getElementById('map-flash-message');
+let showFlag = document.getElementById('dialog-check');
+
+window.onload = function() {
+  if(flashMessage.textContent.length != 0) {
+    show_message(flashMessage.textContent);
+  };
+};
+
+function show_message(message) {
+  flashMessage.textContent = message;
+  showFlag.checked = true;
+  setTimeout( () => { showFlag.checked = false }, 3000 )
+};
+
+export default {
+  show_message
+};

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -265,14 +265,6 @@ header {
   }
 }
 
-.map-container {
-  border-radius: 20px;
-  background-color: $gray-200;
-  height: 500px;
-  margin-bottom: 20px;
-  box-shadow: 0 0 6px 0 rgba(black, 0.2);
-}
-
 .shop-card {
   position: relative;
   border-radius: 20px;
@@ -517,6 +509,15 @@ footer {
 }
 
 // マップ
+.map-container {
+  border-radius: 20px;
+  background-color: $gray-200;
+  height: 500px;
+  margin-bottom: 20px;
+  box-shadow: 0 0 6px 0 rgba(black, 0.2);
+  position: relative;
+}
+
 #map {
   width: 100%;
   height: 100%;
@@ -544,6 +545,102 @@ footer {
 .game-check:checked + label.game-label {
   color: white;
   background: $gray-600;
+}
+
+.icon-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+}
+
+.update-geo-button {
+  width: 35px;
+  height: 35px;
+  background: white;
+  color: $gray-800;
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  border: solid 1px $gray-600;
+  margin: 0 0 10px 10px;
+  padding: 0;
+  font-size: 1.2rem;
+  border-radius: 5px;
+  transition: all 0.3s;
+  &:hover {
+    color: $gray-600;
+  }
+}
+
+.search-around-here-button {
+  width: 35px;
+  height: 35px;
+  background: white;
+  color: $gray-800;
+  position: absolute;
+  left: 0;
+  bottom: 40px;
+  border: solid 1px $gray-600;
+  margin: 0 0 10px 10px;
+  padding: 0;
+  font-size: 1.2rem;
+  border-radius: 5px;
+  transition: all 0.3s;
+  &:hover {
+    color: $gray-600;
+  }
+}
+
+.clear-location-session {
+  width: 35px;
+  height: 35px;
+  background: white;
+  color: $gray-800;
+  position: absolute;
+  left: 0;
+  bottom: 80px;
+  border: solid 1px $gray-600;
+  margin: 0 0 10px 10px;
+  padding: 0;
+  font-size: 1.2rem;
+  border-radius: 5px;
+  transition: all 0.3s;
+  &:hover {
+    color: $gray-600;
+  }
+}
+
+.icon-blue {
+  color:rgb(54, 125, 206);
+}
+
+.map-message-dialog {
+  background: rgba(white, 0.7);
+  border: 1px solid rgba(white, 0.3);
+  box-shadow: 0 0 10px 0 rgba(black, 0.7);
+  will-change: all;
+  position: absolute;
+  top: 0;
+  left: 50%;
+  padding: 0;
+  border-radius: 10px;
+  opacity: 0;
+  transform: translate(-50%, 0%) rotateX(90deg);
+  transition: all 0.3s;
+  p {
+    color: $gray-600;
+    padding: 0;
+    margin: 0;
+  }
+}
+
+#dialog-check:checked ~ .map-message-dialog {
+  top: 10px;
+  padding: 10px 15px;
+  transform: translate(-50%, 0%) rotateX(0deg);
+  opacity: 1;
 }
 
 // 以下iPad縦表示向け

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -630,10 +630,19 @@ footer {
   transform: translate(-50%, 0%) rotateX(90deg);
   transition: all 0.3s;
   p {
+    font-size: 1rem;
     color: $gray-600;
     padding: 0;
     margin: 0;
+    white-space: nowrap;
   }
+}
+
+.own-icon {
+  background: rgb(63, 135, 216);
+  border-radius: 15px;
+  border: solid 4px white;
+  box-shadow: 0 0 10px 0 rgba(black, 0.5);
 }
 
 #dialog-check:checked ~ .map-message-dialog {
@@ -801,6 +810,12 @@ footer {
 
   .select-container {
     width: 49%;
+  }
+
+  .map-message-dialog {
+    p {
+      font-size: 0.7rem;
+    }
   }
 
   #nav-menu-check:checked ~ .user-menu-container > .user-menu {

--- a/app/views/layouts/_filter_form.html.slim
+++ b/app/views/layouts/_filter_form.html.slim
@@ -19,16 +19,5 @@
           .modal-footer
             = link_to t('defaults.clear'), filter_path, method: :delete, class: 'btn btn-cancel rounded-pill'
             = f.submit t('defaults.filter_submit'), class: 'btn btn-glass rounded-pill'
-      .json-data
-        .d-none#pref data-pref="#{@prefectures.to_json only: %i[id name]}"
-        .d-none#city data-city="#{@cities.to_json only: %i[id name]}"
-        .d-none#filter data-filter="#{session.to_json}"
-javascript:
-  const pref = document.getElementById('pref');
-  const prefHash = JSON.parse(pref.getAttribute('data-pref'));
-  const city = document.getElementById('city');
-  const cityHash = JSON.parse(city.getAttribute('data-city'));
-  const filter = document.getElementById('filter');
-  const filterHash = JSON.parse(filter.getAttribute('data-filter'));
 
 = javascript_pack_tag 'form_select'

--- a/app/views/shops/_map_flash_message.html.slim
+++ b/app/views/shops/_map_flash_message.html.slim
@@ -1,0 +1,5 @@
+.map-flash-message 
+  input.d-none#dialog-check type="checkbox"
+  .map-message-dialog.blur
+    p#map-flash-message
+      = flash[:notice] if flash[:notice]

--- a/app/views/shops/_near_shops_search_form.html.slim
+++ b/app/views/shops/_near_shops_search_form.html.slim
@@ -1,6 +1,6 @@
 = form_with url: near_shops_search_path, method: :post, local: true do |f|
   = f.hidden_field :lat, id:"map-lat"
   = f.hidden_field :lng, id:"map-lng"
-  = f.button class: 'search-around-here-button' do 
+  = f.button class: 'search-around-here-button', id: 'search-near_shops_button' do 
     .icon-container class="#{ 'icon-blue' if session[:lat] }"
       = fa_icon 'search'

--- a/app/views/shops/_near_shops_search_form.html.slim
+++ b/app/views/shops/_near_shops_search_form.html.slim
@@ -1,0 +1,6 @@
+= form_with url: set_location_path, method: :post, local: true do |f|
+  = f.hidden_field :lat, id:"map-lat"
+  = f.hidden_field :lng, id:"map-lng"
+  = f.button class: 'search-around-here-button' do 
+    .icon-container class="#{ 'icon-blue' if session[:lat] }"
+      = fa_icon 'search'

--- a/app/views/shops/_near_shops_search_form.html.slim
+++ b/app/views/shops/_near_shops_search_form.html.slim
@@ -1,4 +1,4 @@
-= form_with url: set_location_path, method: :post, local: true do |f|
+= form_with url: near_shops_search_path, method: :post, local: true do |f|
   = f.hidden_field :lat, id:"map-lat"
   = f.hidden_field :lng, id:"map-lng"
   = f.button class: 'search-around-here-button' do 

--- a/app/views/shops/index.html.slim
+++ b/app/views/shops/index.html.slim
@@ -4,7 +4,7 @@
   = render 'map_flash_message'
   = render 'near_shops_search_form'
   - if session[:lat] 
-    = link_to clear_near_shops_search_path, method: :delete, class: 'clear-location-session' do
+    = link_to clear_near_shops_search_path, method: :delete, class: 'clear-location-session', id: 'clear-location-session' do
       .icon-container
         = fa_icon 'trash'
 = render @shops_filter

--- a/app/views/shops/index.html.slim
+++ b/app/views/shops/index.html.slim
@@ -1,5 +1,11 @@
 .col-12.map-container.d-flex.align-items-center.justify-content-center
   #map
+  #geolocation_button
+  = render 'near_shops_search_form'
+  - if session[:lat] 
+    = link_to clear_location_path, method: :delete, class: 'clear-location-session' do
+      .icon-container
+        = fa_icon 'trash'
   .d-none.json-data 
     .d-none#shops-lat-and-lng data-shops-lat-and-lng="#{@shops_lat_and_lng.to_json only: %i[id lat lng]}"
 = render @shops_filter
@@ -12,4 +18,5 @@ script src="https://cdn.maptiler.com/mapbox-gl-leaflet/latest/leaflet-mapbox-gl.
 link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.3/leaflet.css"
 link rel="stylesheet" href="https://cdn.maptiler.com/mapbox-gl-js/v1.5.1/mapbox-gl.css"
 = javascript_pack_tag 'map'
+= javascript_pack_tag 'geolocation'
 //script src="https://maps.googleapis.com/maps/api/js?key=#{ENV['MAPS_API_KEY']}" async defer

--- a/app/views/shops/index.html.slim
+++ b/app/views/shops/index.html.slim
@@ -6,8 +6,6 @@
     = link_to clear_location_path, method: :delete, class: 'clear-location-session' do
       .icon-container
         = fa_icon 'trash'
-  .d-none.json-data 
-    .d-none#shops-lat-and-lng data-shops-lat-and-lng="#{@shops_lat_and_lng.to_json only: %i[id lat lng]}"
 = render @shops_filter
 .col-12.d-flex.align-items-center.justify-content-center
   = paginate @shops_filter

--- a/app/views/shops/index.html.slim
+++ b/app/views/shops/index.html.slim
@@ -1,9 +1,10 @@
 .col-12.map-container.d-flex.align-items-center.justify-content-center
   #map
   #geolocation_button
+  = render 'map_flash_message'
   = render 'near_shops_search_form'
   - if session[:lat] 
-    = link_to clear_location_path, method: :delete, class: 'clear-location-session' do
+    = link_to clear_near_shops_search_path, method: :delete, class: 'clear-location-session' do
       .icon-container
         = fa_icon 'trash'
 = render @shops_filter
@@ -17,4 +18,4 @@ link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.3
 link rel="stylesheet" href="https://cdn.maptiler.com/mapbox-gl-js/v1.5.1/mapbox-gl.css"
 = javascript_pack_tag 'map'
 = javascript_pack_tag 'geolocation'
-//script src="https://maps.googleapis.com/maps/api/js?key=#{ENV['MAPS_API_KEY']}" async defer
+= javascript_pack_tag 'map_flash_message'

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -15,3 +15,6 @@ ja:
     filter_submit: 'フィルター設定'
     form:
       header_search_placeholder: 'フリーワード検索'
+    map_flash_message:
+      clear_near_shops_search: '周辺検索設定をクリアにしました'
+      near_shops_search: 'マップで表示している周囲の店舗を検索しました'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   resources :shops, only: %i[show]
   resource :filter, only: %i[create destroy]
   post 'cities', to: 'filters#cities_select'
+  post 'near_shops_search', to: 'filters#near_shops_search'
+  delete 'clear_near_shops_search', to: 'filters#clear_near_shops_search'
   post 'set_location', to: 'filters#set_location'
-  delete 'clear_location', to: 'filters#clear_location'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,6 @@ Rails.application.routes.draw do
   resources :shops, only: %i[show]
   resource :filter, only: %i[create destroy]
   post 'cities', to: 'filters#cities_select'
+  post 'set_location', to: 'filters#set_location'
+  delete 'clear_location', to: 'filters#clear_location'
 end

--- a/spec/system/map_functions_spec.rb
+++ b/spec/system/map_functions_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+RSpec.describe "MapFunctions", type: :system do
+  describe 'マップ内機能' do
+    context 'マップで表示している周辺の店舗を検索する' do
+      let!(:game) { create(:game, title: 'GAME BEAT') }
+      let!(:far_away_shop) { create(:shop, name: '別店舗', lat: 90, lng: 90) }
+      let!(:near_shop_1) { create(:shop, name: 'タウトーステーション1号店', lat: 30.0, lng: 150.0) }
+      let!(:near_shop_2) { create(:shop, name: 'タウトーステーション2号店', lat: 30.1, lng: 150.1) }
+      let!(:game_machine) { create(:game_machine, game: game, shop: near_shop_1) }
+
+      it '検索中心から近い順番に店舗が表示される' do
+        visit root_path
+        # 擬似的に検索中心をlat: 30, lng: 150にする
+        page.execute_script("document.getElementById('map-lat').value = '30.0000'");
+        page.execute_script("document.getElementById('map-lng').value = '150.0000'");
+        click_button 'search-near_shops_button'
+        expect(page.all('.shop-card')[0]).to have_content(near_shop_1.name)
+        expect(page.all('.shop-card')[1]).to have_content(near_shop_2.name)
+        expect(page.all('.shop-card')[2]).to have_content(far_away_shop.name)
+      end
+
+      it '周辺検索と機種フィルターが同時に機能すること' do
+        visit root_path
+        # 擬似的に検索中心をlat: 30, lng: 150にする
+        page.execute_script("document.getElementById('map-lat').value = '30.0000'");
+        page.execute_script("document.getElementById('map-lng').value = '150.0000'");
+        click_button 'search-near_shops_button'
+        # フィルターをかける
+        click_button 'filter-button'
+        within('.modal') do
+          page.find(".game-label", text: 'GAME BEAT').click
+          click_button 'フィルター設定'
+        end
+        expect(page).to have_content(near_shop_1.name)
+        expect(page).not_to have_content(near_shop_2.name)
+        expect(page).not_to have_content(far_away_shop.name)
+      end
+
+      it '検索後、検索クリアボタンが表示される' do
+        visit root_path
+        click_button 'search-near_shops_button'
+        expect(page.all('a#clear-location-session').length).to eq 1
+      end
+
+      it '検索クリアボタンをクリックすると周辺検索が解除される' do
+        visit root_path
+        # 擬似的に検索中心をlat: 30, lng: 150にする
+        page.execute_script("document.getElementById('map-lat').value = '30.0000'");
+        page.execute_script("document.getElementById('map-lng').value = '150.0000'");
+        click_button 'search-near_shops_button'
+        expect(page.all('.shop-card')[0]).to have_content(near_shop_1.name)
+        expect(page.all('.shop-card')[1]).to have_content(near_shop_2.name)
+        expect(page.all('.shop-card')[2]).to have_content(far_away_shop.name)
+        click_link 'clear-location-session'
+        expect(page.all('.shop-card')[0]).to have_content(far_away_shop.name)
+        expect(page.all('.shop-card')[1]).to have_content(near_shop_1.name)
+        expect(page.all('.shop-card')[2]).to have_content(near_shop_2.name)
+      end
+
+      it '検索後、「マップで表示している周囲の店舗を検索しました」とメッセージが表示される' do
+        visit root_path
+        click_button 'search-near_shops_button'
+        expect(page.find('#map-flash-message')).to have_content('マップで表示している周囲の店舗を検索しました')
+      end
+
+      it '検索クリア後、「周辺検索設定をクリアにしました」とメッセージが表示される' do
+        visit root_path
+        click_button 'search-near_shops_button'
+        click_link 'clear-location-session'
+        expect(page.find('#map-flash-message')).to have_content('周辺検索設定をクリアにしました')
+      end
+    end
+
+    context '現在位置表示ボタンをクリックする' do
+      # RSpec上でgeolocation APIが動作しないためメッセージが表示されることのみ確認を行い
+      # Vueが動作することのみテストしています。
+      it '「現在位置情報を取得しています...」と表示される' do
+        visit root_path
+        click_button 'update-geo-button'
+        expect(page.find('#map-flash-message')).to have_content('現在位置情報を取得しています...')
+      end
+    end
+  end
+end

--- a/spec/system/search_shops_spec.rb
+++ b/spec/system/search_shops_spec.rb
@@ -76,25 +76,5 @@ RSpec.describe "SearchShops", type: :system do
         expect(page).not_to have_content(shop_in_another_pref.name)
       end
     end
-
-    context '現在地周辺でフィルターをかける' do
-      let!(:shop_nearby_user) { create(:shop, lat: '30.0000', lng: '150.0000') }
-      let!(:another_shop) { create(:shop, lat: '0', lng: '0') }
-
-      it 'フィルターをかけたエリアのみ検索結果に表示させる' do
-        visit root_path
-        # 都道府県と市区町村のフィルターをかける
-        click_button 'filter-button'
-        within('.modal') do
-          # 擬似的にgeoLocation APIを再現
-          page.find("label", text: '現在位置周辺を検索する').click
-          page.execute_script("document.getElementById('lat').value = '30.0000'");
-          page.execute_script("document.getElementById('lng').value = '150.0000'");
-          click_button 'フィルター設定'
-        end
-        expect(page).to have_content(shop_nearby_user.name)
-        expect(page).not_to have_content(another_shop.name)
-      end
-    end
   end
 end


### PR DESCRIPTION
## 概要

- 実際にサイトを利用してみて現在地周辺の検索機能が使いづらかったため、地図で表示している地点の周辺店舗を検索する機能へ変更した.
- 上記機能の追加に伴い現在地周辺の検索機能は削除した.
- 現在地を1度取得したらページリロードしても常に表示するよう実装した.
- マップに関するフラッシュメッセージはマップ上に表示するよう実装した.

## コメント
- 実際に使用してみると「こういう機能がほしい」といったアイデアが出てくる. あまり追い求めすぎるとリリースまで時間がかかってしまうので優先度が低い案はIssuesに追加してリリースを優先するようにしたい.