### PR TITLE
テーマ変更を異なるデバイス間でも共有出来るよう変更した

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,6 +33,6 @@ class ApplicationController < ActionController::Base
     gon.selectedCity = session[:city_id]
     gon.prefectures = Prefecture.all.to_json only: %i[id name]
     gon.cities = Prefecture.find(gon.selectedPref).cities.to_json(only: %i[id name]) if gon.selectedPref
-    gon.theme = session[:theme]
+    gon.theme = current_user.theme if logged_in?
   end
 end

--- a/app/controllers/themes_controller.rb
+++ b/app/controllers/themes_controller.rb
@@ -1,5 +1,12 @@
 class ThemesController < ApplicationController
   def create
-    session[:theme] = params[:theme]
+    user = current_user
+    user.update(user_params)
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:theme)
   end
 end

--- a/app/javascript/edit_theme.vue
+++ b/app/javascript/edit_theme.vue
@@ -65,7 +65,9 @@ export default {
       // Rails側にセッションとして記録
       axios
         .post('/theme', {
-        theme: themeName
+          user: {
+            theme: themeName
+          }
         })
     }
   }

--- a/app/javascript/packs/set_theme.js
+++ b/app/javascript/packs/set_theme.js
@@ -1,6 +1,7 @@
 import { color } from './theme_color.js' 
 
-const theme = color[gon.theme]
+let themeName = gon.theme == '' ? 'normal' : gon.theme;
+const theme = color[themeName]
 const root = document.documentElement;
 for(const property in theme) {
   root.style.setProperty(property, theme[property]);

--- a/db/migrate/20210819042702_add_theme_to_user.rb
+++ b/db/migrate/20210819042702_add_theme_to_user.rb
@@ -1,0 +1,5 @@
+class AddThemeToUser < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :theme, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_09_151105) do
+ActiveRecord::Schema.define(version: 2021_08_19_042702) do
 
   create_table "about_games", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.bigint "user_review_id", null: false
@@ -116,6 +116,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_151105) do
     t.datetime "reset_password_email_sent_at"
     t.integer "access_count_to_reset_password_page", default: 0
     t.string "avatar"
+    t.string "theme"
     t.index ["activation_token"], name: "index_users_on_activation_token"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["remember_me_token"], name: "index_users_on_remember_me_token"

--- a/spec/system/theme/theme_spec.rb
+++ b/spec/system/theme/theme_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe "テーマ変更", type: :system do
       # rgb(27, 71, 77)  rgb(55, 13, 98)
       expect(page.find('body').native.css_value('background')).to have_content('rgb(27, 71, 77)'), 'テーマが変更されていません'
       expect(page.find('body').native.css_value('background')).to have_content('rgb(55, 13, 98)'), 'テーマが変更されていません'
+      expect(user.reload.theme).to eq('dark'), 'テーマが変更されていません'
     end
   end
 
@@ -41,6 +42,7 @@ RSpec.describe "テーマ変更", type: :system do
       visit root_path
       expect(page.find('body').native.css_value('background')).to have_content('rgb(27, 71, 77)'), 'テーマが変更されていません'
       expect(page.find('body').native.css_value('background')).to have_content('rgb(55, 13, 98)'), 'テーマが変更されていません'
+      expect(user.reload.theme).to eq('dark'), 'テーマが変更されていません'
     end
   end
 end


### PR DESCRIPTION
## 概要

- テーマの記録方法をセッションからUserモデルのthemeカラムに保存する方法へ変更した.