### PR TITLE
ユーザー投稿の画像プレビューが動作しない場合があったため修正を行った.

### DIFF
--- a/app/views/user_reviews/_user_review.html.slim
+++ b/app/views/user_reviews/_user_review.html.slim
@@ -1,7 +1,7 @@
 .review id="userReivew-#{user_review.id}"
   .user-review-head.d-flex.align-items-center id="userReview-icon-#{user_review.id}" data-url="#{user_review.user.avatar_url_in_review}"
     = image_tag user_review.user.avatar_url_in_review, class: 'rounded-circle icon'
-    .user-name.glass-text
+    .user-name.glass-text id="#{'userReview-nickname-' + user_review.id.to_s if user_review.user.anonymous?}"
       = link_to_if !user_review.user.anonymous?, user_review.user.nickname_in_review, user_path(user_review.user), id: "userReview-nickname-#{user_review.id}"
     span.review-date.glass-text id="userReview-created-at-#{user_review.id}"
       = l user_review.created_at, format: :user_review


### PR DESCRIPTION
## 概要

- ユーザー投稿で匿名設定が有効の場合タグにidが付与されず画像プレビューが動作しなくなっていたため修正を行った.