### PR TITLE
RuboCopの設定ファイルの見直しを行った

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,18 +25,12 @@ Metrics/ClassLength:
   CountComments: false
   Max: 300
 
-Metrics/CyclomaticComplexity:
-  Max: 30
-
 Metrics/LineLength:
   Enabled: false
 
 Metrics/MethodLength:
   CountComments: false
   Max: 30
-
-Metrics/PerceivedComplexity:
-  Max: 9
 
 Naming/AccessorMethodName:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,7 +19,7 @@ Rails:
   Enabled: true
 
 Metrics/AbcSize:
-  Max: 40
+  Max: 25
 
 Metrics/ClassLength:
   CountComments: false

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,7 +26,7 @@ class ApplicationController < ActionController::Base
     @shops = Shop.ransack(search_hash).result
   end
 
-  def set_variable_to_javascript
+  def set_variable_to_javascript # rubocop:disable Metrics/AbcSize
     gon.selectedPref = session[:prefecture_id]
     gon.selectedCity = session[:city_id]
     gon.location = session[:location] if session[:location]

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -13,7 +13,7 @@ class ShopsController < ApplicationController
 
   private
 
-  def set_filter # rubocop:disable Metrics/AbcSize
+  def set_filter # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
     @shops_filter = @shops
     @shops_filter = @shops_filter.in_prefecture(session[:prefecture_id]) if session[:prefecture_id]
     @shops_filter = @shops_filter.in_city(session[:city_id]) if session[:city_id]

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -13,7 +13,7 @@ class ShopsController < ApplicationController
 
   private
 
-  def set_filter
+  def set_filter # rubocop:disable Metrics/AbcSize
     @shops_filter = @shops
     @shops_filter = @shops_filter.in_prefecture(session[:prefecture_id]) if session[:prefecture_id]
     @shops_filter = @shops_filter.in_city(session[:city_id]) if session[:city_id]


### PR DESCRIPTION
## 概要

- Metrics/AbcSizeのポイントを40→25へ変更した.
  - Application#set_variable_to_javascript, Shops#set_filterはどうしてもポイントをオーバーしてしまうためログの出力を非表示する対応をしました.
- Metrics/PerceivedComplexity, Metrics/CyclomaticComplexityチェックのポイントをデフォルト値へ変更した.
  - Shops#set_filterはどうしてもポイントをオーバーしてしまうためログの出力を非表示する対応をしました.