### PR TITLE
Shops#set_filterのリファクタリングを行った

### DIFF
--- a/app/controllers/filters_controller.rb
+++ b/app/controllers/filters_controller.rb
@@ -1,12 +1,13 @@
 class FiltersController < ApplicationController
-  def create
+  def create # rubocop:disable Metrics/AbcSize
     if params[:prefecture]
       session.delete :lat
       session.delete :lng
     end
     session[:prefecture_id] = params[:prefecture]
     session[:city_id] = params[:city]
-    session[:games] = params[:games]
+    # string to boolean
+    session[:games] = params[:games].to_unsafe_hash.transform_values { |v| v == 'true' } if params[:games]
     session[:number_of_searches] = params[:number_of_searches]
     redirect_to root_path
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,6 +16,6 @@ module ApplicationHelper
   end
 
   def game_filtered?(game_id)
-    session.dig(:games, game_id.to_s) == '1'
+    session.dig(:games, game_id.to_s)
   end
 end

--- a/app/views/layouts/_filter_form.html.slim
+++ b/app/views/layouts/_filter_form.html.slim
@@ -10,7 +10,7 @@
             = f.label t('defaults.label_game')
             .game-labels
               - Game.all.each do |game|
-                = f.check_box "games[#{game.id}]", id: "game_#{game.id}", class: 'game-check d-none', checked: "#{'checked' if game_filtered?(game.id)}"
+                = f.check_box "games[#{game.id}]", { id: "game_#{game.id}", class: 'game-check d-none', checked: "#{'checked' if game_filtered?(game.id)}" }, true, false
                 label.game-label.rounded-pill for="game_#{game.id}"
                   = game.title
           .form-group


### PR DESCRIPTION
## 概要

- Shops#set_filter内でマジックナンバーを使用していたためリファクタリングを行った. チェックボックスのvalueをtrue, falseに変更し, sessionにparamsの内容を格納する際にString→Booleanへ型変換をすることで対応しました.
- 店舗情報のソートを現在位置に近い順になるよう変更した.
- Shops#set_filterのMetrics/AbcSize, Metrics/PerceivedComplexityのポイントが基準値以下になったためdisable設定を削除した. 
- Filters#createにMetrics/AbcSizeのdisable設定を追記した.