### PR TITLE
現在位置取得の処理を一部変更した

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,6 +30,7 @@ class ApplicationController < ActionController::Base
     gon.selectedPref = session[:prefecture_id]
     gon.selectedCity = session[:city_id]
     gon.location = [cookies.permanent[:location_lat], cookies.permanent[:location_lng]] if cookies.permanent[:location_lat]
+    gon.isSearchByMapMode = session[:lat].present?
     gon.isTest = Rails.env.test?
     gon.attend_tutorial = cookies.permanent[:attend_tutorial]
     gon.selectedCity = session[:city_id]

--- a/app/javascript/geolocation_button.vue
+++ b/app/javascript/geolocation_button.vue
@@ -34,6 +34,10 @@ export default {
     this.buttonMode = false;
     this.getGeolocation();
     if (this.isGeoChecked) {
+      if (!gon.isSearchByMapMode && this.isCloserThanBefore) {
+        // 現在位置の取得がオンかつマップ検索されていないかつ以前取得した位置情報と比べ1km以上離れている場合ページリロードを実行
+        location.reload();
+      }
       // 現在位置の取得がオンになっていたら５秒に1度現在地の更新を行う。
       // 頻繁に更新をするためRails側でセッションは作成せず地図のマーカーの位置のみを変更する。
       this.intervalFunction = setInterval(this.updateLocation, 5000);
@@ -109,6 +113,11 @@ export default {
     },
     focusCurrentPosition: function() {
       window.globalFunction.focusCurrentPosition([this.latitude, this.longitude]);
+    }
+  },
+  computed: {
+    isCloserThanBefore: function() {
+      return Math.abs(gon.latitude - this.latitude) >= 0.01 || Math.abs(gon.longitude - this.longitude) >= 0.01
     }
   }
 }

--- a/app/javascript/geolocation_button.vue
+++ b/app/javascript/geolocation_button.vue
@@ -86,8 +86,10 @@ export default {
               // ページリロードを実行
               location.reload();
             }
+            if(this.getMode == 'button') {
+              Export.show_message('現在位置を取得しました');
+            }
           })
-        Export.show_message('現在位置を取得しました');
       }
       window.globalFunction.addGeoLocationMarker([this.latitude, this.longitude]);
       if(!this.isGeoChecked) {

--- a/app/javascript/geolocation_button.vue
+++ b/app/javascript/geolocation_button.vue
@@ -27,17 +27,13 @@ export default {
       latitude: gon.location ? gon.location[0] : '',
       longitude: gon.location ? gon.location[1] : '',
       intervalFunction: null,
-      buttonMode: true
+      getMode: true
     }
   },
   mounted: function() {
-    this.buttonMode = false;
+    this.getMode = 'first';
     this.getGeolocation();
     if (this.isGeoChecked) {
-      if (!gon.isSearchByMapMode && this.isCloserThanBefore) {
-        // 現在位置の取得がオンかつマップ検索されていないかつ以前取得した位置情報と比べ1km以上離れている場合ページリロードを実行
-        location.reload();
-      }
       // 現在位置の取得がオンになっていたら５秒に1度現在地の更新を行う。
       // 頻繁に更新をするためRails側でセッションは作成せず地図のマーカーの位置のみを変更する。
       this.intervalFunction = setInterval(this.updateLocation, 5000);
@@ -46,12 +42,12 @@ export default {
   methods: {
     updateLocation: function() {
       if (this.isGeoChecked) {
-        this.buttonMode = false;
+        this.getMode = 'auto';
         this.getGeolocation();
       }
     },
     onGeoButton: function() {
-      this.buttonMode = true;
+      this.getMode = 'button';
       this.getGeolocation();
       if (this.isGeoChecked) {
         // 2回目以降に現在地取得をする場合は現在地のズームを行う
@@ -59,7 +55,7 @@ export default {
       }
     },
     getGeolocation: function() {
-      // buttonMode: true=>現在位置取得ボタンを押した時の挙動
+      // getMode: button=>現在位置取得ボタンを押した時の挙動, atLoad=>画面ロード時の挙動
       if (!navigator.geolocation) {
         Export.show_message('現在位置が取得できませんでした')
         return
@@ -69,7 +65,7 @@ export default {
         timeout: 5000,
         maximumAge: 0
       }
-      if(this.buttonMode) {
+      if(this.getMode == 'button') {
         Export.show_message('現在位置情報を取得しています...');
       }
       navigator.geolocation.getCurrentPosition(this.success, this.error, options)
@@ -77,12 +73,19 @@ export default {
     success: function(position) {
       this.latitude = position.coords.latitude
       this.longitude = position.coords.longitude
-      if(this.buttonMode || !this.isGeoChecked) {
+      if(this.getMode == 'button' || this.getMode == 'first' || !this.isGeoChecked) {
         // Rails側にセッションとして記録
         axios
           .post('/set_location', {
           lat: this.latitude,
           lng: this.longitude
+          })
+          .then(() => {
+            if(this.getMode == 'first' && !gon.isSearchByMapMode && this.isCloserThanBefore) {
+              // 現在位置の取得がオンかつマップ検索されていないかつ以前取得した位置情報と比べ1km以上離れている場合
+              // ページリロードを実行
+              location.reload();
+            }
           })
         Export.show_message('現在位置を取得しました');
       }
@@ -94,7 +97,7 @@ export default {
       }
     },
     error: function(error) {
-      if(this.buttonMode) {
+      if(this.getMode == 'button') {
         switch (error.code) {
           case 1: // PERMISSION_DENIED
             Export.show_message('位置情報の利用が許可されていません')
@@ -117,7 +120,8 @@ export default {
   },
   computed: {
     isCloserThanBefore: function() {
-      return Math.abs(gon.latitude - this.latitude) >= 0.01 || Math.abs(gon.longitude - this.longitude) >= 0.01
+      // 日本の場合経度は1度=約80kmであるがここでは1度約100kmとして計算
+      return Math.abs(gon.location[0] - this.latitude) >= 0.01 || Math.abs(gon.location[1] - this.longitude) >= 0.01
     }
   }
 }


### PR DESCRIPTION
## 概要

- 変更前
  - 現在位置取得後ユーザーがその地点から移動して再度トップページにアクセスすると現在位置周辺検索が上手く機能しなくなる.
  - 原因
    - 初回サイト訪問時, ユーザーが現在位置取得ボタンを押した時のみ現在位置情報をキャッシュするように処理しているため
- 変更後
  - トップページアクセス時に前回の位置情報と現在位置を比較し1km以上離れている場合は位置情報のキャッシュ処理を行いページリロードするよう実装した.