### PR TITLE
匿名設定が無効の状態でも有効時のメッセージが表示されていたため修正した

### DIFF
--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -23,7 +23,8 @@
       = t '.user_reviews_label'
     span.glass-text
       = "#{t '.user_reviews_length'}#{@user_reviews.size}件"
-    p.glass-text.anonymous-explain
-      = t '.user_review_anonymous_exp'
+    - if @user.anonymous?
+      p.glass-text.anonymous-explain
+        = t '.user_review_anonymous_exp'
     ul.profile-user-reviews.mb-3
       = render partial: 'user_review', collection: @user_reviews.limit(5)

--- a/spec/system/users/user_spec.rb
+++ b/spec/system/users/user_spec.rb
@@ -169,6 +169,15 @@ RSpec.describe 'ユーザー', type: :system do
       end
 
       context '匿名設定を無効にする' do
+        before { user.update(anonymous: false) }
+
+        context '自分自身のプロフィールを表示する' do
+          it '注意文「匿名設定が有効のためこの欄は他のユーザーには表示されません。」が表示されないこと' do
+            visit user_path(user)
+            expect(page).not_to have_content('匿名設定が有効のためこの欄は他のユーザーには表示されません。'), '注意文が表示されています'
+          end
+        end
+
         context '他のユーザーで自分のプロフィールを表示' do
           it 'ユーザー投稿に関する部分が表示されること' do
             login another_user


### PR DESCRIPTION
## 概要

- 標記バグの修正を行った. specを追記した.