### PR TITLE
プロフィールページ内ユーザー投稿部の匿名設定とユーザー投稿数0件の差を無くし匿名設定か判別出来ないように変更した

### DIFF
--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -17,7 +17,7 @@
               = game.title
     - if @user == current_user
       = link_to t('.edit_profile'), edit_profile_user_path(@user.id), class: 'btn-glass edit-profile rounded-pill'
-- if current_user == @user || !@user.anonymous?
+- if current_user == @user || ( !@user.anonymous? && @user_reviews.present? )
   .col-12.glass.glass-round
     label.shop-label.rounded-pill.mb-2
       = t '.user_reviews_label'

--- a/spec/system/users/user_spec.rb
+++ b/spec/system/users/user_spec.rb
@@ -179,10 +179,22 @@ RSpec.describe 'ユーザー', type: :system do
         end
 
         context '他のユーザーで自分のプロフィールを表示' do
+          let!(:user_review) { create(:user_review, user: user) }
+
           it 'ユーザー投稿に関する部分が表示されること' do
             login another_user
             visit user_path(user)
             expect(page).to have_content('最近投稿した筐体情報'), 'ユーザー投稿に関する部分が表示されていません'
+          end
+        end
+
+        context '投稿数が0の場合' do
+          it 'ユーザー投稿に関する部分が表示されないこと' do
+            # 匿名設定と表示をあわせるために投稿数が0の場合は非表示にする
+            user.user_reviews.destroy_all
+            login another_user
+            visit user_path(user)
+            expect(page).not_to have_content('最近投稿した筐体情報'), 'ユーザー投稿に関する部分が表示されています'
           end
         end
       end


### PR DESCRIPTION
## 概要

- ユーザー投稿件数0件のユーザーと匿名設定しているユーザーでプロフィールの表示に差があったため変更を行った.
- 当変更は匿名設定しているかを特定出来なくするための変更である.