### PR TITLE
ユーザー作成/削除機能の追加変更を行った

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :set_user, only: %i[show edit update edit_profile update_profile]
+  before_action :set_user, only: %i[show edit update edit_profile update_profile destroy]
   before_action :require_params, only: %i[new_with_twitter]
 
   def new
@@ -72,6 +72,12 @@ class UsersController < ApplicationController
     else
       not_authenticated
     end
+  end
+
+  def destroy
+    authorize @user
+    @user.destroy
+    redirect_to root_url, success: t('.success')
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,7 @@ class User < ApplicationRecord
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
 
   VALID_EMAIL_REGEX = /[a-zA-Z0-9_.+-]+@([a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]*\.)+[a-zA-Z]{2,}/.freeze
-  validates :email, presence: true, uniqueness: { case_sensitive: false }, length: { maximum: 255 }, format: { with: VALID_EMAIL_REGEX }
+  validates :email, presence: true, uniqueness: { case_sensitive: false }, length: { maximum: 255 }, format: { with: VALID_EMAIL_REGEX }, unless: :authentication
   validates :nickname, presence: true, length: { maximum: 30 }
   validates :description, length: { maximum: 300 }
   validates :anonymous, inclusion: { in: [true, false] }

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -14,4 +14,8 @@ class UserPolicy < ApplicationPolicy
   def update_profile?
     user == record
   end
+
+  def destroy?
+    user == record
+  end
 end

--- a/app/views/users/_edit_form.html.slim
+++ b/app/views/users/_edit_form.html.slim
@@ -1,18 +1,16 @@
 .form-container.text-center
-  .page-title
-    h1.page-title-text.glass-text
-      = t 'users.edit.title'
   = render 'shared/error_messages', object: user
   = form_with model: user, id: 'signup_form', class: 'signup-form', local: true do |f|
-    .form-group-signup
-      = f.text_field :email, id: 'userEmail', class: 'glass-text-field', 'v-model': "emailField", '@input': 'emailValid()', ':class': "emailError ? 'error-field' : ''", placeholder: User.human_attribute_name(:email)
-      p.error-text v-text='emailError'
-    .form-group-signup
-      = f.password_field :password, id: 'userPassword', class: 'glass-text-field', 'v-model': 'passwordField', '@input': 'passwordValid()', ':class': "passwordError ? 'error-field' : ''", autocomplete: 'off', placeholder: "#{User.human_attribute_name(:password) + t('defaults.password_valid')}"
-      p.error-text v-text='passwordError'
-    .form-group-signup
-      = f.password_field :password_confirmation, id: 'userPasswordConfirmation', class: 'glass-text-field', 'v-model': 'passwordConfirmationField', ':class': "passwordConfirmationError ? 'error-field' : ''", autocomplete: 'off', '@input': 'passwordConfirmationValid()', placeholder: User.human_attribute_name(:password_confirmation)
-      p.error-text v-text='passwordConfirmationError'
+    - unless user.authentication
+      .form-group-signup
+        = f.text_field :email, id: 'userEmail', class: 'glass-text-field', 'v-model': "emailField", '@input': 'emailValid()', ':class': "emailError ? 'error-field' : ''", placeholder: User.human_attribute_name(:email)
+        p.error-text v-text='emailError'
+      .form-group-signup
+        = f.password_field :password, id: 'userPassword', class: 'glass-text-field', 'v-model': 'passwordField', '@input': 'passwordValid()', ':class': "passwordError ? 'error-field' : ''", autocomplete: 'off', placeholder: "#{User.human_attribute_name(:password) + t('defaults.password_valid')}"
+        p.error-text v-text='passwordError'
+      .form-group-signup
+        = f.password_field :password_confirmation, id: 'userPasswordConfirmation', class: 'glass-text-field', 'v-model': 'passwordConfirmationField', ':class': "passwordConfirmationError ? 'error-field' : ''", autocomplete: 'off', '@input': 'passwordConfirmationValid()', placeholder: User.human_attribute_name(:password_confirmation)
+        p.error-text v-text='passwordConfirmationError'
     .form-group-signup.mb-4
       = f.check_box :anonymous
       = f.label :anonymous, t('defaults.form.anonymous'), class: 'glass-text ms-2 mb-2'

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -2,12 +2,12 @@
   = render 'shared/error_messages', object: user
   = form_with model: user, id: 'signup_form', class: 'signup-form', url: "#{provider ? create_users_with_twitter_path(params.permit(:provider, :uid)) : users_path}", method: :post, local: true do |f|
     .form-group-signup
-      = f.text_field :email, id: 'userEmail', class: 'glass-text-field', 'v-model': "emailField", '@input': 'emailValid()', ':class': "emailError ? 'error-field' : ''", placeholder: User.human_attribute_name(:email)
-      p.error-text v-text='emailError'
     - if provider
       = f.hidden_field :password, value: "A#{Digest::MD5.hexdigest(params[:uid]).slice(0, 29)}"
       = f.hidden_field :password_confirmation, value: "A#{Digest::MD5.hexdigest(params[:uid]).slice(0, 29)}"
     - else
+      = f.text_field :email, id: 'userEmail', class: 'glass-text-field', 'v-model': "emailField", '@input': 'emailValid()', ':class': "emailError ? 'error-field' : ''", placeholder: User.human_attribute_name(:email)
+      p.error-text v-text='emailError'
       .form-group-signup
         = f.password_field :password, id: 'userPassword', class: 'glass-text-field', 'v-model': 'passwordField', '@input': 'passwordValid()', ':class': "passwordError ? 'error-field' : ''", autocomplete: 'off', placeholder: "#{User.human_attribute_name(:password) + t('defaults.password_valid')}"
         p.error-text v-text='passwordError'

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -1,3 +1,8 @@
 - set_meta_tags title: t('.title')
-.col-12.glass.glass-round.d-flex.justify-content-center
-  = render 'edit_form', user: @user
+.col-12.glass.glass-round.text-center
+  h1.page-title-text.glass-text
+    = t '.title'
+  .d-flex.justify-content-center
+    = render 'edit_form', user: @user
+  .mt-4.mb-2
+    = link_to 'アカウントを削除する', user_path(@user), class: 'btn btn-glass rounded-pill px-4', method: :delete, data: { confirm: t('.destroy_confirm') }

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -61,6 +61,7 @@ ja:
     edit:
       title: 'ユーザー設定'
       anonymous_exp: '匿名設定を有効にするとあなたが情報の投稿を行った際、アイコン, ニックネームが表示されなくなります。'
+      destroy_confirm: 'アカウントが削除されると今まで投稿した情報も削除されます。よろしいですか？'
     update:
       success: 'ユーザー設定の変更が完了しました。'
     activate:
@@ -69,6 +70,8 @@ ja:
       title: 'プロフィール編集'
     update_profile:
       success: 'プロフィールを編集しました。'
+    destroy:
+      success: '今までご利用頂きましてありがとうございました。'
   user_sessions:
     new:
       title: 'ログイン'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
     resources :user_reviews, only: %i[create destroy]
   end
   resource :filter, only: %i[create destroy]
-  resources :users, only: %i[create show edit update] do
+  resources :users, only: %i[create show edit update destroy] do
     member do
       get :activate
       get :edit_profile

--- a/db/migrate/20210924023702_modify_email_valid_of_users.rb
+++ b/db/migrate/20210924023702_modify_email_valid_of_users.rb
@@ -1,0 +1,9 @@
+class ModifyEmailValidOfUsers < ActiveRecord::Migration[6.0]
+  def up
+    change_column :users, :email, :string, null: true
+  end
+
+  def down
+    change_column :users, :email, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_16_084715) do
+ActiveRecord::Schema.define(version: 2021_09_24_023702) do
 
   create_table "about_games", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.bigint "user_review_id", null: false
@@ -109,7 +109,7 @@ ActiveRecord::Schema.define(version: 2021_09_16_084715) do
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.string "email", null: false
+    t.string "email"
     t.string "crypted_password"
     t.string "salt"
     t.string "nickname", null: false

--- a/spec/system/users/user_spec.rb
+++ b/spec/system/users/user_spec.rb
@@ -258,5 +258,18 @@ RSpec.describe 'ユーザー', type: :system do
         expect(page).to have_content('パスワード再入力を入力してください'), 'パスワードに関するエラーメッセージが表示されていません'
       end
     end
+
+    context '削除ボタンを押す' do
+      it 'ユーザーが削除されること' do
+        visit edit_user_path(user)
+        expect {
+          page.accept_confirm do
+            click_on 'アカウントを削除する'
+          end
+          expect(current_path).to eq(root_path), 'トップページへリダイレクトされていません'
+          expect(page.find('#flash-message')).to have_content('今までご利用頂きましてありがとうございました。'), 'フラッシュメッセージが表示されてません'
+        }.to change { User.count }.by(-1), 'アカウントが削除されていません'
+      end
+    end
   end
 end


### PR DESCRIPTION
## 概要

- Twitter連携でアカウントを作成する際はメールの記入を不要とした.
- アカウント削除機能を実装した.
- アカウント削除機能に対するspecを追記した.