### PR TITLE
change puma config for production

### DIFF
--- a/config/puma/production.rb
+++ b/config/puma/production.rb
@@ -9,8 +9,9 @@ min_threads_count = ENV.fetch('RAILS_MIN_THREADS') { max_threads_count }
 threads min_threads_count, max_threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
+root_dir = '/var/www/rails/music_game_maps'
 
-bind "unix://#{Rails.root}/tmp/sockets/puma.sock"
+bind "unix://#{root_dir}/tmp/sockets/puma.sock"
 
 # Specifies the `environment` that Puma will run in.
 #


### PR DESCRIPTION
## 概要

- production環境にてpumaをsystemctlでバックグラウンド起動出来るようにした.